### PR TITLE
Enhancements/Treemap: Show/hide colorscale

### DIFF
--- a/dashboards-observability/public/components/visualizations/charts/maps/treemap_type.ts
+++ b/dashboards-observability/public/components/visualizations/charts/maps/treemap_type.ts
@@ -12,6 +12,7 @@ import {
   ConfigValueOptions,
   ColorPalettePicker,
   ConfigChartOptions,
+  ConfigLegend,
 } from '../../../event_analytics/explorer/visualizations/config_panel/config_panes/config_controls';
 import { DEFAULT_PALETTE, COLOR_PALETTES } from '../../../../../common/constants/colors';
 
@@ -44,6 +45,26 @@ export const createTreeMapDefinition = (params: BarTypeParams = {}) => ({
         mapTo: 'dataConfig',
         editor: VizDataPanel,
         sections: [
+          {
+            id: 'legend',
+            name: 'Legend',
+            editor: ConfigLegend,
+            mapTo: 'legend',
+            schemas: [
+              {
+                name: 'Show Colorscale',
+                mapTo: 'showLegend',
+                component: null,
+                props: {
+                  options: [
+                    { name: 'Show', id: 'show' },
+                    { name: 'Hidden', id: 'hidden' },
+                  ],
+                  defaultSelections: [{ name: 'Show', id: 'show' }],
+                },
+              },
+            ],
+          },
           {
             id: 'treemap_options',
             name: 'Treemap',

--- a/dashboards-observability/public/components/visualizations/charts/maps/treemaps.tsx
+++ b/dashboards-observability/public/components/visualizations/charts/maps/treemaps.tsx
@@ -52,6 +52,8 @@ export const TreeMap = ({ visualizations, layout, config }: any) => {
       ? dataConfig?.treemapOptions.tilingAlgorithm[0]
       : 'squarify';
 
+  const showColorscale = dataConfig?.legend?.showLegend ?? 'show';
+
   const areParentFieldsInvalid =
     new Set([...parentFields.map((x) => x.name)]).size !== parentFields.length ||
     parentFields.some((x) => isEmpty(data[x.name]) || isEqual(childField.name, x.name));
@@ -140,6 +142,7 @@ export const TreeMap = ({ visualizations, layout, config }: any) => {
             colorbar: {
               len: 1,
             },
+            showscale: showColorscale === 'show',
           }
         : {};
 


### PR DESCRIPTION
Signed-off-by: Mrunal Zambre <mrunal_zambre@persistent.com>

### Description
Added config option to show/hide colorscale for treemap.

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
